### PR TITLE
Alguns comentários

### DIFF
--- a/P1-QUI/Q1.tex
+++ b/P1-QUI/Q1.tex
@@ -3,17 +3,20 @@
 
 (a) Explique o significado físico da pressão interna.\\
 
-   A pressão interna \( \pi_T \) representa a variação da energia interna com a
-   variação do volume com a temperatura constante. Isto é, como a energia
-   interna varia quando o gás expande ou contrai adiabaticamente. Essa variação
-   de energia interna pode ser justificada por interações atrativas e repulsivas
-   à nível molecular. Desta forma, \( \pi_T = 0 \) para um gás ideal. 
+   \textbf{Resposta:} A pressão interna \( \pi_T \) representa a variação da
+   energia interna com a variação do volume com a temperatura constante. Isto é,
+   como a energia interna varia quando o gás expande ou contrai adiabaticamente.
+   % Adiabaticamente ou isotermicamente?
+   Essa variação de energia interna pode ser justificada por interações
+   atrativas e repulsivas à nível molecular. Desta forma, temos \( \pi_T = 0 \) para
+   um gás ideal. 
 
 (b) Para cada um desses gases, nessas condições, você espera que o valor da
 pressão interna \(\pi_T\)  seja igual, menor ou maior que zero? Discuta as
 condições de contorno consideradas e explique o raciocínio.\\
 
-    À 500 K, em pressão próxima à pressão atmosférica, tanto \ce{H2O(g)} quanto \ce{C2H4(g)} já ebuliram. Desta forma, as
-    interações intermoleculares predominantes em cada um são forças repulsivas.
-    Portanto, ao expandir adiabaticamente, é de se esperar que a energia interna
-    diminua, portanto \( \pi_T < 0 \).  
+    \textbf{Resposta:} À 500 K, em pressão próxima à pressão atmosférica, tanto
+    \ce{H2O(g)} quanto \ce{C2H4(g)} já ebuliram. Desta forma, as interações
+    intermoleculares predominantes em cada um são forças repulsivas.  Portanto,
+    ao expandir adiabaticamente, é de se esperar que a energia interna diminua,
+    portanto \( \pi_T < 0 \).  

--- a/P1-QUI/Q1.tex
+++ b/P1-QUI/Q1.tex
@@ -17,6 +17,8 @@ condições de contorno consideradas e explique o raciocínio.\\
 
     \textbf{Resposta:} À 500 K, em pressão próxima à pressão atmosférica, tanto
     \ce{H2O(g)} quanto \ce{C2H4(g)} já ebuliram. Desta forma, as interações
+    % me parece errado assumir que os gases já ebuliram para justificar essa
+    % questão
     intermoleculares predominantes em cada um são forças repulsivas.  Portanto,
     ao expandir adiabaticamente, é de se esperar que a energia interna diminua,
     portanto \( \pi_T < 0 \).  


### PR DESCRIPTION
Sobre a questão 1, acho válido trocar o uso de adiabático por isotérmico. O próprio Atkins usa esse termo para se referir à pressão interna:
" which represents how the internal energy changes as the volume of a system is changed isothermally, played a central role in the manipulation of the First Law "